### PR TITLE
working again

### DIFF
--- a/assets/javascripts/discourse/components/d-gate.js.es6
+++ b/assets/javascripts/discourse/components/d-gate.js.es6
@@ -15,6 +15,7 @@ export default DiscourseModal.extend({
         this.set('title', I18n.t(data.title));
       }
       $('html').addClass('gg-active');
+      this._modalBodyShown(data);
     });
     this.appEvents.on('modal:body-dismissed', data => {
       $('html').removeClass('gg-active');

--- a/assets/javascripts/discourse/components/d-gate.js.es6
+++ b/assets/javascripts/discourse/components/d-gate.js.es6
@@ -5,6 +5,7 @@ export default DiscourseModal.extend({
   classNameBindings: [':gate'],
   attributeBindings: ['data-keyboard'],
 
+  dismissable: false,
   'data-keyboard': 'true',
 
   @on("didInsertElement")
@@ -14,10 +15,23 @@ export default DiscourseModal.extend({
         this.set('title', I18n.t(data.title));
       }
     });
+
+    $('html').on('keydown.discourse-modal', e => {
+      if ((e.which === 27) && $('.modal-header a.close').is(":visible")) {
+        Em.run.next(() => $('.modal-header a.close').click());
+      }
+    });
   },
 
   click(e) {
-    return true;
+    const $target = $(e.target);
+    if (($target.hasClass("modal-middle-container") ||
+        $target.hasClass("modal-outer-container")) &&
+	$('.modal-header a.close').is(":visible")) {
+      // Delegate click to modal close if clicked outside.
+      // We do this because some CSS of ours seems to cover
+      // the backdrop and makes it unclickable.
+      $('.modal-header a.close').click();
+    }
   }
-
 });

--- a/assets/javascripts/discourse/components/d-gate.js.es6
+++ b/assets/javascripts/discourse/components/d-gate.js.es6
@@ -14,6 +14,10 @@ export default DiscourseModal.extend({
       if (data.title) {
         this.set('title', I18n.t(data.title));
       }
+      $('html').addClass('gg-active');
+    });
+    this.appEvents.on('modal:body-dismissed', data => {
+      $('html').removeClass('gg-active');
     });
 
     $('html').on('keydown.discourse-modal', e => {

--- a/assets/javascripts/discourse/initializers/guest-gate.js.es6
+++ b/assets/javascripts/discourse/initializers/guest-gate.js.es6
@@ -1,4 +1,3 @@
-import { cleanDOM } from 'discourse/lib/clean-dom';
 import { startPageTracking } from 'discourse/lib/page-tracker';
 import { viewTrackingRequired } from 'discourse/lib/ajax';
 import showGate from 'discourse/plugins/guest-gate/discourse/lib/show-gate';
@@ -15,7 +14,6 @@ export default {
         // Tell our AJAX system to track a page transition
         const router = container.lookup('router:main');
         router.on('willTransition', viewTrackingRequired);
-        router.on('didTransition', cleanDOM);
 
         let appEvents = container.lookup('app-events:main');
         startPageTracking(router, appEvents);

--- a/assets/javascripts/discourse/lib/show-gate.js.es6
+++ b/assets/javascripts/discourse/lib/show-gate.js.es6
@@ -11,7 +11,7 @@ export default function(name, opts) {
 
   const controllerName = opts.admin ? `modals/${name}` : name;
 
-  const viewClass = container.lookupFactory('view:' + name);
+  const viewClass = container.factoryFor('view:' + name);
   const controller = container.lookup('controller:' + controllerName);
   if (viewClass) {
     route.render(name, { into: 'modal', outlet: 'modalBody' });

--- a/assets/javascripts/discourse/templates/guest-gate.hbs
+++ b/assets/javascripts/discourse/templates/guest-gate.hbs
@@ -43,9 +43,6 @@
     </div>
   {{/if}}
   <style type="text/css">
-    .modal-middle-container {
-      margin-top: 10%;
-    }
     .gate .modal-header {
       border-bottom: none;
     }

--- a/assets/javascripts/discourse/templates/guest-gate.hbs
+++ b/assets/javascripts/discourse/templates/guest-gate.hbs
@@ -56,9 +56,6 @@
       margin-top: 15px;
       {{/if}}
     }
-    .gate .modal-header h3 {
-      display: none;
-    }
     .modal .modal-body p {
       font-size: 14px;
     }

--- a/assets/javascripts/discourse/templates/guest-gate.hbs
+++ b/assets/javascripts/discourse/templates/guest-gate.hbs
@@ -78,7 +78,7 @@
       color: #787878;
     }
   </style>
-  {{login-buttons action="externalLogin"}}
+  {{login-buttons externalLogin=(action "externalLogin")}}
 {{/d-modal-body}}
 <div class="modal-footer">
   {{#if ssoEnabled}}

--- a/assets/javascripts/discourse/templates/modal.hbs
+++ b/assets/javascripts/discourse/templates/modal.hbs
@@ -1,4 +1,4 @@
-{{#d-gate modalClass=modalClass title=title}}
+{{#d-gate modalClass=modalClass title=title class="hidden"}}
   <div class="modal-outer-container">
     <div class="modal-middle-container">
       <div class="modal-inner-container">

--- a/assets/javascripts/discourse/templates/modal.hbs
+++ b/assets/javascripts/discourse/templates/modal.hbs
@@ -5,7 +5,7 @@
         <div class="modal-header">
           <h3>{{title}}</h3>
           <div class="modal-close">
-            <a class="close" {{action "closeModal"}}>{{fa-icon "times"}}</a>
+            <a class="close" {{action "closeModal"}}>{{d-icon "times"}}</a>
           </div>
         </div>
         <div id='modal-alert'></div>

--- a/assets/javascripts/discourse/templates/modal.hbs
+++ b/assets/javascripts/discourse/templates/modal.hbs
@@ -1,4 +1,4 @@
-{{#d-gate modalClass=modalClass title=title class="hidden"}}
+{{#d-gate modalClass=modalClass title=title class="gg-hide-modal"}}
   <div class="modal-outer-container">
     <div class="modal-middle-container">
       <div class="modal-inner-container">

--- a/assets/stylesheets/guest-gate.scss
+++ b/assets/stylesheets/guest-gate.scss
@@ -1,0 +1,3 @@
+#discourse-modal.gg-hide-modal {
+  display: none;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2,7 +2,7 @@ en:
   js:
     guest_gate:
       modal:
-        title: "Why do I need to sign in?"
+        title: "Please Sign Up!"
         sign_up_email: "Sign Up with Email"
         sign_up: "Sign Up"
         log_in: "I already have an account"

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,5 +1,6 @@
 # name: guest-gate
 # about: Force guest users to create an account by preventing them from seeing more topics
-# version: 0.2.1
-# authors: Vinoth Kannan (vinothkannan@vinkas.com) and jgujgu
-# url: https://github.com/jgujgu/discourse-guest-gate
+# version: 0.3
+# authors: Vinoth Kannan (vinothkannan@vinkas.com) and jgujgu and michael@discoursehosting.com
+# url: https://github.com/discoursehosting/discourse-guest-gate
+#

--- a/plugin.rb
+++ b/plugin.rb
@@ -5,3 +5,5 @@
 # url: https://github.com/discoursehosting/discourse-guest-gate
 
 enabled_site_setting :guest_gate_enabled
+
+register_asset "stylesheets/guest-gate.scss"

--- a/plugin.rb
+++ b/plugin.rb
@@ -3,4 +3,5 @@
 # version: 0.3
 # authors: Vinoth Kannan (vinothkannan@vinkas.com) and jgujgu and michael@discoursehosting.com
 # url: https://github.com/discoursehosting/discourse-guest-gate
-#
+
+enabled_site_setting :guest_gate_enabled


### PR DESCRIPTION
Fixed all issues so the plugin works with Discourse 2.3 and up again.

Also the plugin now supports a blur. To enable this, create a theme component with the following CSS.

```
/* Blur for the Guest Gate plugin */
/* More blur --> change the 3's to a higher number */
/* Less blur --> change the 3's to a lower number */

html.gg-active #main-outlet {
    -webkit-filter: blur(3px);
    -moz-filter: blur(3px);
    -o-filter: blur(3px);
    -ms-filter: blur(3px);
    filter: blur(3px);
}

/* Background transparency for the Guest Gate modal */
/* Darker --> change the 0.3's / 30 to a higher number */
/* Lighter --> change the 0.3's / 30 to a lower number */

html.gg-active .modal-backdrop,
html.gg-active .modal-backdrop.fade.in {
  animation: fade 0.3s;
  opacity: 0.3;
  filter: alpha(opacity=30);
}
```
